### PR TITLE
factory pid wrong

### DIFF
--- a/src/main/jbake/content/documentation/the-sling-engine/featureflags.md
+++ b/src/main/jbake/content/documentation/the-sling-engine/featureflags.md
@@ -18,7 +18,7 @@ Features may be enabled based on various contextual data:
 
 Feature flags can be provided by registering `org.apache.sling.featureflags.Feature` services.
 Alternatively feature flags can be provided by factory configuration with factory PID
-`org.apache.sling.featureflags.Feature` as follows:
+`org.apache.sling.featureflags.impl.ConfiguredFeature` as follows:
 
 | Property | Description |
 |--|--|


### PR DESCRIPTION
Changed between 1.0.0 (AEM 6.1) and 1.2.0 (AEM 6.3). OSGi configuration based feature flags are no longer picked up by the system when they use org.apache.sling.featureflags.Feature as the factory PID. It should now be org.apache.sling.featureflags.impl.ConfiguredFeature.